### PR TITLE
Actually drop the reference to the _savedScope

### DIFF
--- a/EntityFramework.Implementation/AmbientContextSuppressor.cs
+++ b/EntityFramework.Implementation/AmbientContextSuppressor.cs
@@ -16,7 +16,6 @@ namespace Numero3.EntityFramework.Implementation
 
         public AmbientContextSuppressor()
         {
-            _disposed = false;
             _savedScope = DbContextScope.GetAmbientScope();
 
             // We're hiding the ambient scope but not removing its instance
@@ -50,6 +49,7 @@ namespace Numero3.EntityFramework.Implementation
             if (_savedScope != null)
             {
                 DbContextScope.SetAmbientScope(_savedScope);
+                _savedScope = null;
             }
 
             _disposed = true;


### PR DESCRIPTION
This change will let the GC collect the scope sooner. Also removed the init of _disposed to false. It's a bool and those are false by default.
