### PR TITLE
Constrain on IDbContext instead of DbContext for easier unit testing and mocking

### DIFF
--- a/DemoApplication/DatabaseContext/UserManagementDbContext.cs
+++ b/DemoApplication/DatabaseContext/UserManagementDbContext.cs
@@ -1,10 +1,11 @@
 ﻿using System.Data.Entity;
 using System.Reflection;
+using Mehdime.Entity;
 using Numero3.EntityFramework.Demo.DomainModel;
 
 namespace Numero3.EntityFramework.Demo.DatabaseContext
 {
-	public class UserManagementDbContext : DbContext
+	public class UserManagementDbContext : DbContext, IDbContext
 	{
 		// Map our 'User' model by convention
 		public DbSet<User> Users { get; set; }

--- a/Mehdime.Entity/Implementations/AmbientDbContextLocator.cs
+++ b/Mehdime.Entity/Implementations/AmbientDbContextLocator.cs
@@ -11,7 +11,7 @@ namespace Mehdime.Entity
 {
     public class AmbientDbContextLocator : IAmbientDbContextLocator
     {
-        public TDbContext Get<TDbContext>() where TDbContext : DbContext
+        public TDbContext Get<TDbContext>() where TDbContext : class, IDbContext
         {
             var ambientDbContextScope = DbContextScope.GetAmbientScope();
             return ambientDbContextScope == null ? null : ambientDbContextScope.DbContexts.Get<TDbContext>();

--- a/Mehdime.Entity/Implementations/DbContextCollection.cs
+++ b/Mehdime.Entity/Implementations/DbContextCollection.cs
@@ -29,30 +29,30 @@ namespace Mehdime.Entity
     /// </summary>
     public class DbContextCollection : IDbContextCollection
     {
-        private Dictionary<Type, DbContext> _initializedDbContexts;
-        private Dictionary<DbContext, DbContextTransaction> _transactions; 
+        private Dictionary<Type, IDbContext> _initializedDbContexts;
+        private Dictionary<IDbContext, DbContextTransaction> _transactions; 
         private IsolationLevel? _isolationLevel;
         private readonly IDbContextFactory _dbContextFactory;
         private bool _disposed;
         private bool _completed;
         private bool _readOnly;
 
-        internal Dictionary<Type, DbContext> InitializedDbContexts { get { return _initializedDbContexts; } }
+        internal Dictionary<Type, IDbContext> InitializedDbContexts { get { return _initializedDbContexts; } }
 
         public DbContextCollection(bool readOnly = false, IsolationLevel? isolationLevel = null, IDbContextFactory dbContextFactory = null)
         {
             _disposed = false;
             _completed = false;
 
-            _initializedDbContexts = new Dictionary<Type, DbContext>();
-            _transactions = new Dictionary<DbContext, DbContextTransaction>();
+            _initializedDbContexts = new Dictionary<Type, IDbContext>();
+            _transactions = new Dictionary<IDbContext, DbContextTransaction>();
 
             _readOnly = readOnly;
             _isolationLevel = isolationLevel;
             _dbContextFactory = dbContextFactory;
         }
 
-        public TDbContext Get<TDbContext>() where TDbContext : DbContext
+        public TDbContext Get<TDbContext>() where TDbContext : class, IDbContext
         {
             if (_disposed)
                 throw new ObjectDisposedException("DbContextCollection");

--- a/Mehdime.Entity/Interfaces/IAmbientDbContextLocator.cs
+++ b/Mehdime.Entity/Interfaces/IAmbientDbContextLocator.cs
@@ -5,21 +5,35 @@
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.
  */
+
+using System;
 using System.Data.Entity;
+using System.Data.Entity.Infrastructure;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Mehdime.Entity
 {
     /// <summary>
-    /// Convenience methods to retrieve ambient DbContext instances. 
+    ///     Convenience methods to retrieve ambient DbContext instances.
     /// </summary>
     public interface IAmbientDbContextLocator
     {
         /// <summary>
-        /// If called within the scope of a DbContextScope, gets or creates 
-        /// the ambient DbContext instance for the provided DbContext type. 
-        /// 
-        /// Otherwise returns null. 
+        ///     If called within the scope of a DbContextScope, gets or creates
+        ///     the ambient DbContext instance for the provided DbContext type.
+        ///     Otherwise returns null.
         /// </summary>
-        TDbContext Get<TDbContext>() where TDbContext : DbContext;
+        TDbContext Get<TDbContext>() where TDbContext : class, IDbContext;
+    }
+
+    public interface IDbContext : IDisposable
+    {
+        DbContextConfiguration Configuration { get; }
+        Database Database { get; }
+
+        int SaveChanges();
+
+        Task<int> SaveChangesAsync(CancellationToken cancelToken);
     }
 }

--- a/Mehdime.Entity/Interfaces/IAmbientDbContextLocator.cs
+++ b/Mehdime.Entity/Interfaces/IAmbientDbContextLocator.cs
@@ -7,10 +7,6 @@
  */
 
 using System;
-using System.Data.Entity;
-using System.Data.Entity.Infrastructure;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Mehdime.Entity
 {
@@ -25,15 +21,5 @@ namespace Mehdime.Entity
         ///     Otherwise returns null.
         /// </summary>
         TDbContext Get<TDbContext>() where TDbContext : class, IDbContext;
-    }
-
-    public interface IDbContext : IDisposable
-    {
-        DbContextConfiguration Configuration { get; }
-        Database Database { get; }
-
-        int SaveChanges();
-
-        Task<int> SaveChangesAsync(CancellationToken cancelToken);
     }
 }

--- a/Mehdime.Entity/Interfaces/IDbContext.cs
+++ b/Mehdime.Entity/Interfaces/IDbContext.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Data.Entity;
+using System.Data.Entity.Infrastructure;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mehdime.Entity
+{
+    public interface IDbContext : IDisposable
+    {
+        DbContextConfiguration Configuration { get; }
+        Database Database { get; }
+
+        int SaveChanges();
+
+        Task<int> SaveChangesAsync(CancellationToken cancelToken);
+    }
+}

--- a/Mehdime.Entity/Interfaces/IDbContextCollection.cs
+++ b/Mehdime.Entity/Interfaces/IDbContextCollection.cs
@@ -18,6 +18,6 @@ namespace Mehdime.Entity
         /// <summary>
         /// Get or create a DbContext instance of the specified type. 
         /// </summary>
-		TDbContext Get<TDbContext>() where TDbContext : DbContext;
+		TDbContext Get<TDbContext>() where TDbContext : class, IDbContext;
     }
 }

--- a/Mehdime.Entity/Interfaces/IDbContextFactory.cs
+++ b/Mehdime.Entity/Interfaces/IDbContextFactory.cs
@@ -33,6 +33,6 @@ namespace Mehdime.Entity
     /// </remarks>
     public interface IDbContextFactory
     {
-		TDbContext CreateDbContext<TDbContext>() where TDbContext : IDbContext;
+		TDbContext CreateDbContext<TDbContext>() where TDbContext : class, IDbContext;
     }
 }

--- a/Mehdime.Entity/Interfaces/IDbContextFactory.cs
+++ b/Mehdime.Entity/Interfaces/IDbContextFactory.cs
@@ -33,6 +33,6 @@ namespace Mehdime.Entity
     /// </remarks>
     public interface IDbContextFactory
     {
-		TDbContext CreateDbContext<TDbContext>() where TDbContext : DbContext;
+		TDbContext CreateDbContext<TDbContext>() where TDbContext : IDbContext;
     }
 }

--- a/Mehdime.Entity/Mehdime.Entity.csproj
+++ b/Mehdime.Entity/Mehdime.Entity.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Implementations\DbContextScopeFactory.cs" />
     <Compile Include="Enums\DbContextScopeOption.cs" />
     <Compile Include="Interfaces\IAmbientDbContextLocator.cs" />
+    <Compile Include="Interfaces\IDbContext.cs" />
     <Compile Include="Interfaces\IDbContextCollection.cs" />
     <Compile Include="Interfaces\IDbContextFactory.cs" />
     <Compile Include="Interfaces\IDbContextReadOnlyScope.cs" />


### PR DESCRIPTION
Because the TDbContext generics are constrained with `where TDbContext : DbContext`, I have to call all the relevant methods with concrete class types.  This makes for more difficult unit testing because I will eventually have to mock a concrete DbContext class somewhere.  

If we instead constrain on the new IDbContext that only defines methods that the library needs (and DbContext already implements), then I can inherit this interface on my DbContext interfaces and mock much easier.

This is a breaking change, of course, because any client code that would upgrade to this change would need to implement the IDbContext interface on all their client DbContexts.
