### PR TITLE
Create overload without parameter to replace parameter with default null

### DIFF
--- a/Mehdime.Entity/Implementations/DbContextScopeFactory.cs
+++ b/Mehdime.Entity/Implementations/DbContextScopeFactory.cs
@@ -14,7 +14,11 @@ namespace Mehdime.Entity
     {
         private readonly IDbContextFactory _dbContextFactory;
 
-        public DbContextScopeFactory(IDbContextFactory dbContextFactory = null)
+        public DbContextScopeFactory()
+        {
+        }
+
+        public DbContextScopeFactory(IDbContextFactory dbContextFactory)
         {
             _dbContextFactory = dbContextFactory;
         }


### PR DESCRIPTION
The `DbContextScopeFactory` class has a constructor with an optional argument. Optional arguments are not well supported by IoC libraries. In particular, SimpleInjector does not support them at all.

This commit refactors that constructor by splitting it into overloads with and without arguments.

Resolves #37
